### PR TITLE
feat: redesign graph visualization with vis-network and custom node i…

### DIFF
--- a/frontend/app/explorer/page.tsx
+++ b/frontend/app/explorer/page.tsx
@@ -1,9 +1,10 @@
 'use client'
+
 import React, { useState, useEffect, useCallback, useRef } from 'react'
 import axios from 'axios'
-import { ResizablePanelGroup, ResizablePanel } from '@/components/ui/resizable'
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { ScrollArea } from '@/components/ui/scroll-area' // FIX: Update thi s path if the file is located elsewhere, e.g. '@/components/scroll-area'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import { FileTree } from '@/components/file-tree'
 import { IssuesList } from '@/components/issues-list'
 import { CodeViewer } from '@/components/code-viewer'
@@ -12,7 +13,17 @@ import { Neo4jGraph } from '@/components/neo4j-graph-visualizer'
 import { MarkdownRenderer } from '@/components/markdown'
 import { useSearchParams } from 'next/navigation'
 import { Card, CardContent } from '@/components/ui/card'
-import { AlertCircle, Loader2 } from 'lucide-react'
+import {
+  AlertCircle,
+  Loader2,
+  BookOpen,
+  GitBranch,
+  Code2,
+  MessageSquare,
+  NetworkIcon,
+  FolderOpen,
+  ExternalLink,
+} from 'lucide-react'
 
 interface RepoSummaryResponse {
   folder_path: string
@@ -24,176 +35,212 @@ interface RepoSummaryResponse {
 }
 
 export default function ExplorerPage() {
-  
   const [selectedFile, setSelectedFile] = useState<string | null>(null)
   const [localFilePath, setLocalFilePath] = useState<string>('')
   const [repo, setRepo] = useState<string>('')
+  const [repoName, setRepoName] = useState<string>('')
   const [repoSummary, setRepoSummary] = useState<string>('')
   const [summaryLoading, setSummaryLoading] = useState<boolean>(false)
   const [summaryError, setSummaryError] = useState<string | null>(null)
+  const [activeTab, setActiveTab] = useState('issues')
 
-  // Add this ref to track if summary has been fetched
   const summaryFetched = useRef<string | null>(null)
-
   const searchParams = useSearchParams()
 
   useEffect(() => {
     const pathFromUrl = searchParams.get('localFilePath')
     const repoFromUrl = searchParams.get('repo')
 
-    console.log('local file path:', pathFromUrl)
-
-    if (pathFromUrl) {
-      setLocalFilePath(pathFromUrl)
-    }
+    if (pathFromUrl) setLocalFilePath(pathFromUrl)
     if (repoFromUrl) {
       setRepo(repoFromUrl)
+      // Extract human-readable repo name from URL
+      try {
+        const parts = new URL(repoFromUrl).pathname.split('/').filter(Boolean)
+        setRepoName(parts.length >= 2 ? `${parts[0]}/${parts[1]}` : repoFromUrl)
+      } catch {
+        setRepoName(repoFromUrl)
+      }
     }
 
     const fetchRepoSummary = async () => {
-      // Prevent duplicate calls for the same path
-      if (!pathFromUrl || summaryFetched.current === pathFromUrl) {
-        return
-      }
-
-      console.log('Fetching summary for path:', pathFromUrl)
+      if (!pathFromUrl || summaryFetched.current === pathFromUrl) return
       summaryFetched.current = pathFromUrl
       setSummaryLoading(true)
       setSummaryError(null)
-
       try {
-        const response = await axios.post<RepoSummaryResponse>(
-          '/api/summarize-folder/',
-          {
-            localRepoPath: pathFromUrl,
-          }
-        )
-
+        const response = await axios.post<RepoSummaryResponse>('/api/summarize-folder/', {
+          localRepoPath: pathFromUrl,
+        })
         if (response.data.status === 'success') {
           setRepoSummary(response.data.root_summary)
         } else {
           setSummaryError('Failed to fetch repository summary')
         }
       } catch (error) {
-        console.error('Error fetching repository summary:', error)
-        // Reset the ref on error so retry is possible
         summaryFetched.current = null
-
-        let errorMessage = 'An unexpected error occurred'
-
+        let msg = 'An unexpected error occurred'
         if (axios.isAxiosError(error)) {
-          if (error.response?.status === 404) {
-            errorMessage = 'Repository path not found'
-          } else if (error.response?.status === 400) {
-            errorMessage = 'Invalid repository path'
-          } else if (error.response?.status === 500) {
-            errorMessage = 'Server error while processing repository'
-          } else {
-            errorMessage =
-              error.response?.data?.detail ||
-              error.response?.data?.message ||
-              'Failed to fetch repository summary'
-          }
+          if (error.response?.status === 404) msg = 'Repository path not found'
+          else if (error.response?.status === 400) msg = 'Invalid repository path'
+          else if (error.response?.status === 500) msg = 'Server error while processing repository'
+          else msg = error.response?.data?.detail || error.response?.data?.message || 'Failed to fetch repository summary'
         }
-
-        setSummaryError(errorMessage)
+        setSummaryError(msg)
       } finally {
         setSummaryLoading(false)
       }
     }
 
-    if (pathFromUrl) {
-      fetchRepoSummary()
-    }
+    if (pathFromUrl) fetchRepoSummary()
   }, [searchParams])
 
-  // Memoize the setSelectedFile callback to prevent unnecessary rerenders
   const handleFileSelect = useCallback((file: string | null) => {
     setSelectedFile(file)
+    setActiveTab('code')
   }, [])
 
+  const TABS = [
+    { value: 'summary', label: 'Summary',  Icon: BookOpen },
+    { value: 'issues',  label: 'Issues',   Icon: AlertCircle },
+    { value: 'code',    label: 'Code',     Icon: Code2 },
+    { value: 'chat',    label: 'Chat',     Icon: MessageSquare },
+    { value: 'neo4j',   label: 'Graph',    Icon: NetworkIcon },
+  ]
+
   return (
-    <div className='h-screen bg-background'>
-      <ResizablePanelGroup direction='horizontal'>
-        <ResizablePanel defaultSize={25} minSize={20} maxSize={40}>
-          <div className='h-screen flex flex-col'>
-            <div className='p-4 border-b'>
-              <h2 className='text-lg font-semibold'>Repository Structure</h2>
-            </div>
-            <ScrollArea className='flex-1'>
-              <div className='p-4'>
-                <FileTree
-                  onSelect={handleFileSelect}
-                  rootPath={localFilePath}
-                />
-              </div>
-            </ScrollArea>
+    <div className="h-screen flex flex-col bg-background overflow-hidden">
+
+      {/* ── Top header bar ─────────────────────────────────────────────────── */}
+      <header className="flex items-center gap-3 px-4 h-11 border-b bg-background/95 backdrop-blur
+        supports-[backdrop-filter]:bg-background/60 flex-shrink-0 z-10">
+        <div className="flex items-center gap-2 text-sm font-medium text-foreground/90">
+          <GitBranch className="w-4 h-4 text-muted-foreground" />
+          <span className="text-muted-foreground">CodeExplorer</span>
+          {repoName && (
+            <>
+              <span className="text-muted-foreground/40">/</span>
+              <span className="font-semibold text-foreground">{repoName}</span>
+              {repo && (
+                <a href={repo} target="_blank" rel="noopener noreferrer"
+                  className="text-muted-foreground hover:text-foreground transition-colors">
+                  <ExternalLink className="w-3.5 h-3.5" />
+                </a>
+              )}
+            </>
+          )}
+        </div>
+        {selectedFile && (
+          <div className="flex items-center gap-1.5 ml-2 text-xs text-muted-foreground">
+            <span className="text-muted-foreground/40">·</span>
+            <Code2 className="w-3.5 h-3.5" />
+            <span className="font-mono truncate max-w-xs">{selectedFile.split(/[/\\]/).pop()}</span>
           </div>
-        </ResizablePanel>
-        <ResizablePanel defaultSize={75}>
-          <Tabs defaultValue='issues' className='h-screen flex flex-col'>
-            <div className='px-4 m-3 pt-2 border-b'>
-              <TabsList className='flex justify-between'>
-                <TabsTrigger value='summary'>Repo Summary</TabsTrigger>
-                <TabsTrigger value='issues'>Issues</TabsTrigger>
-                <TabsTrigger value='code'>Code Viewer</TabsTrigger>
-                <TabsTrigger value='chat'>Chat Bot</TabsTrigger>
-                <TabsTrigger value='neo4j'>CodeBase Graph</TabsTrigger>
-              </TabsList>
+        )}
+      </header>
+
+      {/* ── Two-pane body ──────────────────────────────────────────────────── */}
+      <div className="flex-1 overflow-hidden">
+        <ResizablePanelGroup direction="horizontal" className="h-full">
+
+          {/* Left: file tree */}
+          <ResizablePanel defaultSize={22} minSize={15} maxSize={40}>
+            <div className="h-full flex flex-col border-r">
+              <div className="flex items-center gap-2 px-4 h-10 border-b bg-muted/20 flex-shrink-0">
+                <FolderOpen className="w-4 h-4 text-muted-foreground" />
+                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                  Files
+                </span>
+              </div>
+              <ScrollArea className="flex-1">
+                <div className="p-2">
+                  <FileTree onSelect={handleFileSelect} rootPath={localFilePath} />
+                </div>
+              </ScrollArea>
             </div>
-            <div className='flex-1 p-4'>
-              <TabsContent value='summary' className='h-full'>
-                {summaryLoading ? (
-                  <Card className='h-full border shadow-md'>
-                    <CardContent className='flex items-center justify-center h-full'>
-                      <div className='flex flex-col items-center space-y-4'>
-                        <Loader2 className='w-8 h-8 animate-spin text-primary' />
-                        <p className='text-muted-foreground'>
-                          Loading repository summary...
-                        </p>
-                      </div>
-                    </CardContent>
-                  </Card>
-                ) : summaryError ? (
-                  <Card className='h-full border shadow-md'>
-                    <CardContent className='flex items-center justify-center h-full'>
-                      <div className='flex flex-col items-center space-y-4 text-center'>
-                        <AlertCircle className='w-8 h-8 text-destructive' />
-                        <div>
-                          <p className='text-destructive font-medium'>
-                            Error Loading Summary
-                          </p>
-                          <p className='text-muted-foreground text-sm mt-1'>
-                            {summaryError}
-                          </p>
+          </ResizablePanel>
+
+          <ResizableHandle withHandle />
+
+          {/* Right: tabbed content */}
+          <ResizablePanel defaultSize={78}>
+            <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
+
+              {/* Tab bar */}
+              <div className="flex-shrink-0 border-b bg-background px-2 pt-1">
+                <TabsList className="h-9 bg-transparent gap-0 p-0">
+                  {TABS.map(({ value, label, Icon }) => (
+                    <TabsTrigger
+                      key={value}
+                      value={value}
+                      className="relative h-9 px-4 rounded-none border-b-2 border-transparent text-xs font-medium
+                        text-muted-foreground transition-none
+                        data-[state=active]:border-primary data-[state=active]:text-foreground
+                        data-[state=active]:bg-transparent hover:text-foreground gap-1.5"
+                    >
+                      <Icon className="w-3.5 h-3.5" />
+                      {label}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+              </div>
+
+              {/* Tab panels */}
+              <div className="flex-1 overflow-hidden">
+
+                <TabsContent value="summary" className="h-full m-0 p-4 overflow-auto">
+                  {summaryLoading ? (
+                    <Card className="h-full border shadow-sm">
+                      <CardContent className="flex items-center justify-center h-full">
+                        <div className="flex flex-col items-center gap-3">
+                          <Loader2 className="w-7 h-7 animate-spin text-primary" />
+                          <p className="text-sm text-muted-foreground">Generating repository summary…</p>
                         </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                ) : (
-                  <MarkdownRenderer content={repoSummary} />
-                )}
-              </TabsContent>
-              <TabsContent value='issues' className='h-full'>
-                <IssuesList repoURL={repo} />
-              </TabsContent>
-              <TabsContent value='code' className='h-full overflow-hidden'>
-                <CodeViewer file={selectedFile} />
-              </TabsContent>
-              <TabsContent value='chat' className='h-full'>
-                <ChatBot />
-              </TabsContent>
-              <TabsContent value='neo4j' className='h-full'>
-                <Neo4jGraph
-                  uri={process.env.NEXT_PUBLIC_NEO4J_URI!}
-                  user={process.env.NEXT_PUBLIC_NEO4J_USER!}
-                  password={process.env.NEXT_PUBLIC_NEO4J_PASSWORD!}
-                />
-              </TabsContent>
-            </div>
-          </Tabs>
-        </ResizablePanel>
-      </ResizablePanelGroup>
+                      </CardContent>
+                    </Card>
+                  ) : summaryError ? (
+                    <Card className="h-full border shadow-sm">
+                      <CardContent className="flex items-center justify-center h-full">
+                        <div className="flex flex-col items-center gap-3 text-center">
+                          <AlertCircle className="w-7 h-7 text-destructive" />
+                          <div>
+                            <p className="text-destructive font-medium text-sm">Error Loading Summary</p>
+                            <p className="text-muted-foreground text-xs mt-1">{summaryError}</p>
+                          </div>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  ) : (
+                    <MarkdownRenderer content={repoSummary} />
+                  )}
+                </TabsContent>
+
+                <TabsContent value="issues" className="h-full m-0 p-4 overflow-hidden">
+                  <IssuesList repoURL={repo} />
+                </TabsContent>
+
+                <TabsContent value="code" className="h-full m-0 overflow-hidden">
+                  <CodeViewer file={selectedFile} />
+                </TabsContent>
+
+                <TabsContent value="chat" className="h-full m-0 p-4 overflow-hidden">
+                  <ChatBot />
+                </TabsContent>
+
+                <TabsContent value="neo4j" className="h-full m-0 overflow-hidden p-2">
+                  <Neo4jGraph
+                    uri={process.env.NEXT_PUBLIC_NEO4J_URI!}
+                    user={process.env.NEXT_PUBLIC_NEO4J_USER!}
+                    password={process.env.NEXT_PUBLIC_NEO4J_PASSWORD!}
+                  />
+                </TabsContent>
+
+              </div>
+            </Tabs>
+          </ResizablePanel>
+
+        </ResizablePanelGroup>
+      </div>
     </div>
   )
 }

--- a/frontend/components/file-tree.tsx
+++ b/frontend/components/file-tree.tsx
@@ -1,7 +1,28 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { ChevronRight, ChevronDown, File, Folder, Loader2 } from 'lucide-react'
+import {
+  ChevronRight,
+  ChevronDown,
+  Loader2,
+  FileCode2,
+  FileText,
+  FileJson,
+  FileImage,
+  Folder,
+  FolderOpen,
+  Settings,
+  TestTube2,
+  Globe,
+  Braces,
+  BookOpen,
+  FileType2,
+  Terminal,
+  Database,
+  Package,
+  Lock,
+  AlertCircle,
+} from 'lucide-react'
 import { cn } from '@/lib/utils'
 import axios from 'axios'
 
@@ -17,165 +38,280 @@ interface FileTreeProps {
   onSelect: (filePath: string) => void
 }
 
+// ─── Extension → icon + color map ────────────────────────────────────────────
+type FileIconConfig = {
+  Icon: React.ComponentType<any>
+  color: string
+}
+
+const EXT_MAP: Record<string, FileIconConfig> = {
+  // Python
+  py:   { Icon: FileCode2,  color: '#3B82F6' },
+  pyi:  { Icon: FileCode2,  color: '#60A5FA' },
+  // JavaScript / TypeScript
+  js:   { Icon: FileCode2,  color: '#EAB308' },
+  jsx:  { Icon: FileCode2,  color: '#06B6D4' },
+  ts:   { Icon: FileCode2,  color: '#3B82F6' },
+  tsx:  { Icon: FileCode2,  color: '#06B6D4' },
+  mjs:  { Icon: FileCode2,  color: '#EAB308' },
+  cjs:  { Icon: FileCode2,  color: '#EAB308' },
+  // Web
+  html: { Icon: Globe,      color: '#F97316' },
+  htm:  { Icon: Globe,      color: '#F97316' },
+  css:  { Icon: FileType2,  color: '#EC4899' },
+  scss: { Icon: FileType2,  color: '#EC4899' },
+  sass: { Icon: FileType2,  color: '#EC4899' },
+  less: { Icon: FileType2,  color: '#A78BFA' },
+  // Data / Config
+  json: { Icon: Braces,     color: '#F59E0B' },
+  yaml: { Icon: Settings,   color: '#8B5CF6' },
+  yml:  { Icon: Settings,   color: '#8B5CF6' },
+  toml: { Icon: Settings,   color: '#F97316' },
+  ini:  { Icon: Settings,   color: '#94A3B8' },
+  cfg:  { Icon: Settings,   color: '#94A3B8' },
+  env:  { Icon: Lock,       color: '#F59E0B' },
+  // Docs
+  md:   { Icon: BookOpen,   color: '#94A3B8' },
+  mdx:  { Icon: BookOpen,   color: '#60A5FA' },
+  txt:  { Icon: FileText,   color: '#94A3B8' },
+  rst:  { Icon: FileText,   color: '#94A3B8' },
+  // Database
+  sql:  { Icon: Database,   color: '#22D3EE' },
+  db:   { Icon: Database,   color: '#22D3EE' },
+  // Test files (by name convention handled separately)
+  // Shell
+  sh:   { Icon: Terminal,   color: '#34D399' },
+  bash: { Icon: Terminal,   color: '#34D399' },
+  zsh:  { Icon: Terminal,   color: '#34D399' },
+  // Images
+  png:  { Icon: FileImage,  color: '#A78BFA' },
+  jpg:  { Icon: FileImage,  color: '#A78BFA' },
+  jpeg: { Icon: FileImage,  color: '#A78BFA' },
+  svg:  { Icon: FileImage,  color: '#F97316' },
+  gif:  { Icon: FileImage,  color: '#A78BFA' },
+  webp: { Icon: FileImage,  color: '#A78BFA' },
+  // JSON variants
+  jsonc:{ Icon: Braces,     color: '#F59E0B' },
+  // Lock / manifest
+  lock: { Icon: Lock,       color: '#94A3B8' },
+  // Java / JVM
+  java: { Icon: FileCode2,  color: '#F97316' },
+  kt:   { Icon: FileCode2,  color: '#A78BFA' },
+  // Go
+  go:   { Icon: FileCode2,  color: '#06B6D4' },
+  // Rust
+  rs:   { Icon: FileCode2,  color: '#F97316' },
+  // C / C++
+  c:    { Icon: FileCode2,  color: '#60A5FA' },
+  cpp:  { Icon: FileCode2,  color: '#60A5FA' },
+  h:    { Icon: FileCode2,  color: '#94A3B8' },
+  // Ruby
+  rb:   { Icon: FileCode2,  color: '#EF4444' },
+  // PHP
+  php:  { Icon: FileCode2,  color: '#A78BFA' },
+  // Package
+  xml:  { Icon: FileJson,   color: '#F59E0B' },
+}
+
+function getFileIconConfig(name: string): FileIconConfig {
+  // Test file heuristic
+  if (name.match(/\.(test|spec)\.[jt]sx?$/) || name.startsWith('test_') || name.endsWith('_test.py')) {
+    return { Icon: TestTube2, color: '#60A5FA' }
+  }
+  // Package / manifest
+  if (name === 'package.json' || name === 'pyproject.toml' || name === 'setup.py' || name === 'Cargo.toml') {
+    return { Icon: Package, color: '#F59E0B' }
+  }
+  // Dotfiles
+  if (name === '.gitignore' || name === '.gitattributes') {
+    return { Icon: Settings, color: '#94A3B8' }
+  }
+  if (name.startsWith('.env')) {
+    return { Icon: Lock, color: '#F59E0B' }
+  }
+  if (name === 'Dockerfile' || name === 'docker-compose.yml' || name === 'docker-compose.yaml') {
+    return { Icon: Package, color: '#06B6D4' }
+  }
+  if (name === 'Makefile') {
+    return { Icon: Terminal, color: '#34D399' }
+  }
+  // By extension
+  const ext = name.split('.').pop()?.toLowerCase() || ''
+  return EXT_MAP[ext] || { Icon: FileText, color: '#64748B' }
+}
+
+// ─── Tree node component ──────────────────────────────────────────────────────
+function TreeNodeItem({
+  node,
+  level = 0,
+  onSelect,
+  selectedPath,
+}: {
+  node: TreeNode
+  level?: number
+  onSelect: (path: string) => void
+  selectedPath?: string | null
+}) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [children, setChildren] = useState<TreeNode[]>([])
+  const [childrenLoading, setChildrenLoading] = useState(false)
+
+  const isSelected = node.type === 'file' && node.path === selectedPath
+  const { Icon, color } = getFileIconConfig(node.name)
+
+  const loadChildren = async () => {
+    if (node.type === 'directory' && !children.length) {
+      try {
+        setChildrenLoading(true)
+        const res = await axios.get(`/api/directory?path=${encodeURIComponent(node.path)}`)
+        setChildren(res.data)
+      } catch {
+        // silently fail
+      } finally {
+        setChildrenLoading(false)
+      }
+    }
+  }
+
+  const handleClick = async () => {
+    if (node.type === 'directory') {
+      await loadChildren()
+      setIsOpen(o => !o)
+    } else {
+      onSelect(node.path)
+    }
+  }
+
+  return (
+    <div>
+      <div
+        onClick={handleClick}
+        className={cn(
+          'flex items-center gap-1.5 py-[3px] pr-2 rounded-md cursor-pointer select-none transition-colors group',
+          isSelected
+            ? 'bg-accent text-accent-foreground'
+            : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+        )}
+        style={{ paddingLeft: `${8 + level * 14}px` }}
+      >
+        {/* Expand/collapse for directories */}
+        <span className="w-4 flex-shrink-0 flex items-center justify-center">
+          {node.type === 'directory'
+            ? childrenLoading
+              ? <Loader2 className="w-3 h-3 animate-spin" />
+              : isOpen
+                ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground/70" />
+                : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground/50 group-hover:text-muted-foreground/70" />
+            : null}
+        </span>
+
+        {/* Icon */}
+        {node.type === 'directory' ? (
+          isOpen
+            ? <FolderOpen className="w-4 h-4 flex-shrink-0 text-yellow-400/80" />
+            : <Folder className="w-4 h-4 flex-shrink-0 text-yellow-400/60 group-hover:text-yellow-400/80" />
+        ) : (
+          <Icon className="w-4 h-4 flex-shrink-0" style={{ color }} />
+        )}
+
+        {/* Name */}
+        <span className={cn(
+          'text-xs truncate flex-1',
+          node.type === 'directory' ? 'font-medium' : '',
+          isSelected ? 'text-accent-foreground font-medium' : ''
+        )}>
+          {node.name}
+        </span>
+      </div>
+
+      {/* Children */}
+      {isOpen && node.type === 'directory' && children.length > 0 && (
+        <div className="relative">
+          {/* Vertical indent guide line */}
+          <div
+            className="absolute top-0 bottom-0 w-px bg-border/50"
+            style={{ left: `${8 + level * 14 + 9}px` }}
+          />
+          {children.map((child, i) => (
+            <TreeNodeItem
+              key={`${child.path}-${i}`}
+              node={child}
+              level={level + 1}
+              onSelect={onSelect}
+              selectedPath={selectedPath}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Main FileTree ─────────────────────────────────────────────────────────────
 export function FileTree({ rootPath, onSelect }: FileTreeProps) {
   const [data, setData] = useState<TreeNode[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-
-  const fetchDirectory = async (path: string) => {
-    try {
-      const response = await axios.get(
-        `/api/directory?path=${encodeURIComponent(path)}`
-      )
-
-      return response.data
-    } catch (err) {
-      let errorMessage = 'Failed to fetch directory contents'
-      if (axios.isAxiosError(err)) {
-        errorMessage = err.response?.data?.error || err.message
-      }
-      throw new Error(errorMessage)
-    }
-  }
+  const [selectedPath, setSelectedPath] = useState<string | null>(null)
 
   useEffect(() => {
-    const loadStructure = async () => {
+    const load = async () => {
+      if (!rootPath) {
+        setError('No root path provided')
+        setLoading(false)
+        return
+      }
       try {
         setLoading(true)
         setError(null)
-        console.log('Loading structure for path:', rootPath)
-
-        const initialData = await fetchDirectory(rootPath)
-        console.log('Received initial data:', initialData)
-
-        setData(initialData)
+        const res = await axios.get(`/api/directory?path=${encodeURIComponent(rootPath)}`)
+        setData(res.data)
       } catch (err) {
-        console.error('Error loading structure:', err)
-        setError(
-          err instanceof Error ? err.message : 'Failed to load structure'
-        )
+        setError(axios.isAxiosError(err) ? err.response?.data?.error || err.message : 'Failed to load structure')
       } finally {
         setLoading(false)
       }
     }
-
-    if (rootPath) {
-      loadStructure()
-    } else {
-      setError('No root path provided')
-      setLoading(false)
-    }
+    load()
   }, [rootPath])
 
-  const TreeNode = ({
-    node,
-    level = 0,
-  }: {
-    node: TreeNode
-    level?: number
-  }) => {
-    const [isOpen, setIsOpen] = useState(false)
-    const [children, setChildren] = useState<TreeNode[]>([])
-    const [childrenLoading, setChildrenLoading] = useState(false)
-
-    const loadChildren = async () => {
-      if (node.type === 'directory' && !children.length) {
-        try {
-          setChildrenLoading(true)
-          console.log('Loading children for:', node.path)
-
-          const childNodes = await fetchDirectory(node.path)
-          console.log('Received children:', childNodes)
-
-          setChildren(childNodes)
-        } catch (err) {
-          console.error('Error loading children:', err)
-        } finally {
-          setChildrenLoading(false)
-        }
-      }
-    }
-
-    return (
-      <div>
-        <div
-          className={cn(
-            'flex items-center gap-2 p-1 rounded-md hover:bg-accent cursor-pointer',
-            'text-sm text-muted-foreground hover:text-foreground'
-          )}
-          style={{ paddingLeft: `${level * 12}px` }}
-          onClick={async () => {
-            if (node.type === 'directory') {
-              await loadChildren()
-              setIsOpen(!isOpen)
-            } else {
-              onSelect(node.path)
-            }
-          }}
-        >
-          {node.type === 'directory' ? (
-            <>
-              {childrenLoading ? (
-                <Loader2 className='w-4 h-4 animate-spin' />
-              ) : isOpen ? (
-                <ChevronDown className='w-4 h-4' />
-              ) : (
-                <ChevronRight className='w-4 h-4' />
-              )}
-              <Folder className='w-4 h-4' />
-            </>
-          ) : (
-            <>
-              <span className='w-4' />
-              <File className='w-4 h-4' />
-            </>
-          )}
-          <span className='truncate'>{node.name}</span>
-        </div>
-        {isOpen && node.type === 'directory' && (
-          <div>
-            {children.map((child, index) => (
-              <TreeNode
-                key={`${child.path}-${index}`}
-                node={child}
-                level={level + 1}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-    )
+  const handleSelect = (path: string) => {
+    setSelectedPath(path)
+    onSelect(path)
   }
 
   if (loading) {
     return (
-      <div className='flex items-center justify-center h-full'>
-        <Loader2 className='w-8 h-8 animate-spin text-muted-foreground' />
+      <div className="flex items-center justify-center py-10">
+        <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
       </div>
     )
   }
 
   if (error) {
     return (
-      <div className='p-4 text-red-500 text-sm'>
-        Error: {error}
-        <div className='mt-2 text-xs'>
-          Check that:
-          <ul className='list-disc pl-4'>
-            <li>{rootPath}</li>
-            <li>Backend server is running on port 8000</li>
-            <li>CORS is properly configured</li>
-            <li>Path is accessible to the server</li>
-          </ul>
+      <div className="p-3">
+        <div className="flex items-start gap-2 text-destructive text-xs p-2 rounded-md bg-destructive/10 border border-destructive/20">
+          <AlertCircle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+          <div>
+            <p className="font-medium mb-1">Could not load files</p>
+            <p className="text-muted-foreground">{error}</p>
+          </div>
         </div>
       </div>
     )
   }
 
   return (
-    <div className='space-y-1 overflow-auto'>
-      {data.map((node, index) => (
-        <TreeNode key={`${node.path}-${index}`} node={node} />
+    <div className="space-y-0.5">
+      {data.map((node, i) => (
+        <TreeNodeItem
+          key={`${node.path}-${i}`}
+          node={node}
+          level={0}
+          onSelect={handleSelect}
+          selectedPath={selectedPath}
+        />
       ))}
     </div>
   )

--- a/frontend/components/neo4j-graph-visualizer.tsx
+++ b/frontend/components/neo4j-graph-visualizer.tsx
@@ -1,15 +1,43 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
-import { ChevronUp, ChevronDown, Play, Info } from 'lucide-react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import dynamic from 'next/dynamic'
-import { ScrollArea } from '@/components/ui/scroll-area'
+import * as neo4j from 'neo4j-driver'
+import type {
+  Node as Neo4jNode,
+  Relationship as Neo4jRelationship,
+  Path as Neo4jPath,
+} from 'neo4j-driver'
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible'
+  Play,
+  ZoomIn,
+  ZoomOut,
+  Maximize2,
+  Zap,
+  ZapOff,
+  GitBranch,
+  Layers,
+  Search,
+  X,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  Database,
+  Share2,
+  NetworkIcon,
+  FileCode2,
+  BookOpen,
+  Folder as FolderIcon,
+  Braces,
+  Globe,
+  LayoutTemplate,
+  FlaskConical,
+  HelpCircle,
+  Copy,
+  Check,
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
 import {
   Select,
   SelectContent,
@@ -17,18 +45,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import * as neo4j from 'neo4j-driver'
-import type {
-  Node as Neo4jNode,
-  Relationship as Neo4jRelationship,
-  Path as Neo4jPath,
-} from 'neo4j-driver'
+import type { VisGraphCanvasHandle } from './vis-graph-canvas'
 
-const DynamicNVLComponents = dynamic(() => import('./neo4j-nvl-components'), {
-  ssr: false,
-})
+// Dynamically load vis-network canvas (no SSR)
+const VisGraphCanvas = dynamic(() => import('./vis-graph-canvas'), { ssr: false })
 
-interface Node {
+// ─── Types ────────────────────────────────────────────────────────────────────
+interface NodeData {
   id: string
   caption: string
   color?: string
@@ -36,7 +59,7 @@ interface Node {
   displayName?: string
 }
 
-interface Relationship {
+interface EdgeData {
   id: string
   from: string
   to: string
@@ -49,192 +72,157 @@ interface Neo4jGraphProps {
   password: string
 }
 
+// ─── Node type config ─────────────────────────────────────────────────────────
+const NODE_CONFIG: Record<
+  string,
+  { color: string; label: string; Icon: React.ComponentType<any> }
+> = {
+  DataFile:          { color: '#FF6B6B', label: 'Source File',  Icon: FileCode2 },
+  DocumentationFile: { color: '#4D8AF0', label: 'Documentation',Icon: BookOpen },
+  Folder:            { color: '#6BCB77', label: 'Folder',       Icon: FolderIcon },
+  Function:          { color: '#845EC2', label: 'Function',     Icon: Braces },
+  ApiEndpoint:       { color: '#F97316', label: 'API Endpoint', Icon: Globe },
+  TemplateMarkupFile:{ color: '#F59E0B', label: 'Template',     Icon: LayoutTemplate },
+  TestingFile:       { color: '#60A5FA', label: 'Test File',    Icon: FlaskConical },
+}
 
+const DEFAULT_COLOR = '#94A3B8'
+
+// ─── Relationship colors ──────────────────────────────────────────────────────
+const REL_COLORS: Record<string, string> = {
+  BELONGS_TO: '#6BCB77',
+  CALLS:      '#F97316',
+  TEST:       '#60A5FA',
+  GET:        '#22D3EE',
+  POST:       '#A78BFA',
+  PUT:        '#F59E0B',
+  DELETE:     '#F87171',
+  PATCH:      '#34D399',
+}
+
+// ─── Query templates ──────────────────────────────────────────────────────────
 const QUERY_TEMPLATES = [
-  {
-    label: 'Get All Relationships',
-    query: 'MATCH p=()-[]->() RETURN p LIMIT 25;',
-  },
-  {
-    label: 'Count Node Types',
-    query: 'MATCH (n) RETURN labels(n) as NodeType, count(*) as Count;',
-  },
-  {
-    label: 'Find Connected Nodes',
-    query: 'MATCH (a)-[r]->(b) RETURN a.name, type(r), b.name LIMIT 25;',
-  },
-  {
-    label: 'Shortest Paths',
-    query: 'MATCH p=shortestPath((a)-[*]-(b)) RETURN p LIMIT 5;',
-  },
-  {
-    label: 'Nodes with Most Connections',
-    query:
-      'MATCH (n)-[r]->() RETURN n, count(r) as connections ORDER BY connections DESC LIMIT 10;',
-  },
+  { label: 'All Relationships (25)',    query: 'MATCH p=()-[]->() RETURN p LIMIT 25' },
+  { label: 'File → Function calls',    query: 'MATCH p=(f:DataFile)-[:BELONGS_TO*0..1]-(fn:Function) RETURN p LIMIT 40' },
+  { label: 'API Endpoints',            query: 'MATCH p=(f)-[r:GET|POST|PUT|DELETE|PATCH]->(api:ApiEndpoint) RETURN p LIMIT 30' },
+  { label: 'Folder tree',              query: 'MATCH p=(:Folder)-[:BELONGS_TO*1..3]->(:Folder) RETURN p LIMIT 30' },
+  { label: 'Test coverage',            query: 'MATCH p=(t:TestingFile)-[:TEST]->(n) RETURN p LIMIT 30' },
+  { label: 'Docs & templates',         query: 'MATCH p=(n)-[]->() WHERE n:DocumentationFile OR n:TemplateMarkupFile RETURN p LIMIT 20' },
+  { label: 'Nodes with most edges',    query: 'MATCH (n)-[r]->() RETURN n, count(r) AS c ORDER BY c DESC LIMIT 10' },
+  { label: 'Count all node types',     query: 'MATCH (n) RETURN labels(n)[0] AS type, count(*) AS total ORDER BY total DESC' },
 ]
 
-export const Neo4jGraph = ({ uri, user, password }: Neo4jGraphProps) => {
-  const [queryInput, setQueryInput] = useState(
-    'MATCH p=()-[]->() RETURN p LIMIT 25;'
-  )
-  const [nodes, setNodes] = useState<Node[]>([])
-  const [relationships, setRelationships] = useState<Relationship[]>([])
+// ─── Helper: derive display name ──────────────────────────────────────────────
+function getDisplayName(node: Neo4jNode, label: string): string {
+  const p = node.properties
+  switch (label) {
+    case 'Function':           return p.function_name?.toString() || label
+    case 'ApiEndpoint':        return p.endpoint_name?.toString() || p.endpoint?.toString() || label
+    case 'Folder':             return p.folder_name?.toString() || label
+    default:                   return p.file_name?.toString() || p.name?.toString() || label
+  }
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+export function Neo4jGraph({ uri, user, password }: Neo4jGraphProps) {
+  const [queryInput, setQueryInput] = useState(QUERY_TEMPLATES[0].query)
+  const [nodes, setNodes] = useState<NodeData[]>([])
+  const [relationships, setRelationships] = useState<EdgeData[]>([])
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
-  const [isNodesOpen, setIsNodesOpen] = useState(true)
-  const [isRelationshipsOpen, setIsRelationshipsOpen] = useState(true)
-  const [isPropertiesOpen, setIsPropertiesOpen] = useState(true)
+  const [isStabilizing, setIsStabilizing] = useState(false)
   const [isMounted, setIsMounted] = useState(false)
-  const [selectedNode, setSelectedNode] = useState<Node | null>(null)
+  const [selectedNode, setSelectedNode] = useState<NodeData | null>(null)
+  const [physicsEnabled, setPhysicsEnabled] = useState(true)
+  const [graphLayout, setGraphLayout] = useState<'forceDirected' | 'hierarchical'>('forceDirected')
+  const [searchTerm, setSearchTerm] = useState('')
+  const [copiedQuery, setCopiedQuery] = useState(false)
 
-  // Get unique node types for the legend
-  const nodeTypes = Array.from(new Set(nodes.map((node) => node.caption)))
+  const canvasRef = useRef<VisGraphCanvasHandle>(null)
 
-  // Get unique relationship types for the legend
-  const relationshipTypes = Array.from(
-    new Set(relationships.map((rel) => rel.caption))
+  useEffect(() => { setIsMounted(true) }, [])
+
+  // ── Derived counts ─────────────────────────────────────────────────────────
+  const nodeTypeCounts = nodes.reduce<Record<string, number>>((acc, n) => {
+    acc[n.caption] = (acc[n.caption] || 0) + 1
+    return acc
+  }, {})
+
+  const relTypeCounts = relationships.reduce<Record<string, number>>((acc, r) => {
+    acc[r.caption] = (acc[r.caption] || 0) + 1
+    return acc
+  }, {})
+
+  const filteredNodeTypes = Object.entries(nodeTypeCounts).filter(([type]) =>
+    !searchTerm || type.toLowerCase().includes(searchTerm.toLowerCase())
   )
 
-  const getColorForLabel = (label: string): string => {
-    const colorMap: { [key: string]: string } = {
-      DataFile: '#FF6B6B',
-      DocumentationFile: '#4D8AF0',
-      Folder: '#6BCB77',
-      Function: '#845EC2',
-      ApiEndpoint: '#FF8066',
-      TemplateMarkupFile: '#FFB88C',
-      TestingFile: '#A5A5A5',
-    }
-    return colorMap[label] || '#CCCCCC'
-  }
+  // ── Process raw Neo4j records ──────────────────────────────────────────────
+  const processRecords = useCallback((records: neo4j.Record[]): { nodes: NodeData[]; relationships: EdgeData[] } => {
+    const nodesMap = new Map<string, NodeData>()
+    const relsMap = new Map<string, EdgeData>()
 
-  // Get appropriate display name based on node type and properties
-  const getNodeDisplayName = (node: Neo4jNode, nodeLabel: string): string => {
-    const properties = node.properties
-
-    switch (nodeLabel) {
-      case 'Function':
-        return properties.function_name?.toString() || nodeLabel
-      case 'ApiEndpoint':
-        return properties.endpoint?.toString() || nodeLabel
-      case 'DataFile':
-      case 'DocumentationFile':
-      case 'TemplateMarkupFile':
-        return properties.file_name?.toString() || nodeLabel
-      case 'Folder':
-        return properties.folder_name?.toString() || nodeLabel
-      default:
-        // For other types, try to find a name property
-        return properties.name?.toString() || nodeLabel
-    }
-  }
-
-  const processNeo4jData = (records: neo4j.Record[]) => {
-    const nodesMap = new Map<string, Node>()
-    const relationshipsMap = new Map<string, Relationship>()
-
-    records.forEach((record: neo4j.Record) => {
-      record.keys.forEach((key) => {
+    records.forEach(record => {
+      record.keys.forEach(key => {
         const value = record.get(key)
 
         if (value instanceof neo4j.types.Path) {
           const path = value as Neo4jPath
-
-          path.segments.forEach(
-            (segment: {
-              start: Neo4jNode
-              end: Neo4jNode
-              relationship: Neo4jRelationship
-            }) => {
-              // Process start node
-              const startNode = segment.start
-              const startLabel = startNode.labels[0] || 'Unknown'
-
-              // Get display name based on node type and available properties
-              const startDisplayName = getNodeDisplayName(startNode, startLabel)
-
-              nodesMap.set(startNode.elementId, {
-                id: startNode.elementId,
-                caption: startLabel,
-                color: getColorForLabel(startLabel),
-                properties: startNode.properties,
-                displayName: startDisplayName,
-              })
-
-              // Process relationship
-              const relationship = segment.relationship
-              relationshipsMap.set(relationship.elementId, {
-                id: relationship.elementId,
-                from: startNode.elementId,
-                to: segment.end.elementId,
-                caption: relationship.type,
-              })
-
-              // Process end node
-              const endNode = segment.end
-              const endLabel = endNode.labels[0] || 'Unknown'
-
-              // Get display name based on node type and available properties
-              const endDisplayName = getNodeDisplayName(endNode, endLabel)
-
-              nodesMap.set(endNode.elementId, {
-                id: endNode.elementId,
-                caption: endLabel,
-                color: getColorForLabel(endLabel),
-                properties: endNode.properties,
-                displayName: endDisplayName,
+          path.segments.forEach(seg => {
+            const addNode = (n: Neo4jNode) => {
+              const lbl = n.labels[0] || 'Unknown'
+              nodesMap.set(n.elementId, {
+                id: n.elementId,
+                caption: lbl,
+                color: NODE_CONFIG[lbl]?.color || DEFAULT_COLOR,
+                properties: n.properties,
+                displayName: getDisplayName(n, lbl),
               })
             }
-          )
+            addNode(seg.start)
+            addNode(seg.end)
+            const rel = seg.relationship as Neo4jRelationship
+            relsMap.set(rel.elementId, {
+              id: rel.elementId,
+              from: seg.start.elementId,
+              to: seg.end.elementId,
+              caption: rel.type,
+            })
+          })
         } else if (value instanceof neo4j.types.Node) {
-          // Handle direct node results
-          const node = value as Neo4jNode
-          const nodeLabel = node.labels[0] || 'Unknown'
-
-          // Get display name based on node type and available properties
-          const displayName = getNodeDisplayName(node, nodeLabel)
-
-          nodesMap.set(node.elementId, {
-            id: node.elementId,
-            caption: nodeLabel,
-            color: getColorForLabel(nodeLabel),
-            properties: node.properties,
-            displayName: displayName,
+          const lbl = value.labels[0] || 'Unknown'
+          nodesMap.set(value.elementId, {
+            id: value.elementId,
+            caption: lbl,
+            color: NODE_CONFIG[lbl]?.color || DEFAULT_COLOR,
+            properties: value.properties,
+            displayName: getDisplayName(value, lbl),
           })
         }
       })
     })
 
-    return {
-      nodes: Array.from(nodesMap.values()),
-      relationships: Array.from(relationshipsMap.values()),
-    }
-  }
+    return { nodes: Array.from(nodesMap.values()), relationships: Array.from(relsMap.values()) }
+  }, [])
 
+  // ── Run Cypher ─────────────────────────────────────────────────────────────
   const handleRunQuery = async () => {
     setIsLoading(true)
     setError(null)
     setSelectedNode(null)
+    setIsStabilizing(true)
+
     const driver = neo4j.driver(uri, neo4j.auth.basic(user, password))
     const session = driver.session()
 
     try {
       const result = await session.run(queryInput)
-      const { nodes, relationships } = processNeo4jData(result.records)
-
-      console.log('Processed Nodes:')
-      console.log(JSON.stringify(nodes, null, 2))
-      console.log('Processed Relationships:')
-      console.log(JSON.stringify(relationships, null, 2))
-
-      setNodes(nodes)
-      setRelationships(relationships)
-    } catch (error) {
-      setError(
-        error instanceof Error ? error.message : 'An unknown error occurred'
-      )
-      console.error('Query Error:', error)
+      const processed = processRecords(result.records)
+      setNodes(processed.nodes)
+      setRelationships(processed.relationships)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+      setIsStabilizing(false)
     } finally {
       setIsLoading(false)
       await session.close()
@@ -242,239 +230,389 @@ export const Neo4jGraph = ({ uri, user, password }: Neo4jGraphProps) => {
     }
   }
 
-  // Handle selecting a predefined query template
-  const handleQueryTemplateSelect = (value: string) => {
-    const selectedTemplate = QUERY_TEMPLATES.find(
-      (template) => template.label === value
-    )
-    if (selectedTemplate) {
-      setQueryInput(selectedTemplate.query)
-    }
+  const handleTemplateSelect = (label: string) => {
+    const t = QUERY_TEMPLATES.find(t => t.label === label)
+    if (t) setQueryInput(t.query)
   }
 
-  // Handle node click from the visualization
-  const handleNodeClick = (node: Node) => {
-    setSelectedNode(node)
-    setIsPropertiesOpen(true)
+  const handlePhysicsToggle = () => {
+    const next = !physicsEnabled
+    setPhysicsEnabled(next)
+    canvasRef.current?.togglePhysics(next)
   }
 
-  // Client-side only effect
-  useEffect(() => {
-    setIsMounted(true)
-  }, [])
+  const handleLayoutToggle = () => {
+    setGraphLayout(prev => prev === 'forceDirected' ? 'hierarchical' : 'forceDirected')
+  }
 
+  const handleCopyQuery = async () => {
+    await navigator.clipboard.writeText(queryInput)
+    setCopiedQuery(true)
+    setTimeout(() => setCopiedQuery(false), 1500)
+  }
+
+  // ─── Render ─────────────────────────────────────────────────────────────────
   return (
-    <div className='w-full h-screen flex flex-col bg-gray-900 border-rounded-t-md'>
-      <div className='p-4 bg-gray-800 border-b border-gray-700 flex items-center gap-3 '>
-        <Select onValueChange={handleQueryTemplateSelect}>
-          <SelectTrigger className='w-[280px] bg-gray-700 text-gray-100'>
-            <SelectValue placeholder='Select Query Template' />
+    <div className="w-full h-full flex flex-col bg-[#0a0f1e] text-slate-100 overflow-hidden rounded-lg border border-slate-800">
+
+      {/* ── Top query bar ────────────────────────────────────────────────────── */}
+      <div className="flex items-center gap-2 px-3 py-2 bg-[#0d1424] border-b border-slate-800 flex-shrink-0">
+        <Database className="w-4 h-4 text-slate-500 flex-shrink-0" />
+
+        <Select onValueChange={handleTemplateSelect}>
+          <SelectTrigger className="w-52 h-8 bg-slate-800/60 border-slate-700 text-slate-300 text-xs">
+            <SelectValue placeholder="Query templates…" />
           </SelectTrigger>
-          <SelectContent>
-            {QUERY_TEMPLATES.map((template, index) => (
-              <SelectItem key={index} value={template.label}>
-                {template.label}
+          <SelectContent className="bg-slate-900 border-slate-700">
+            {QUERY_TEMPLATES.map(t => (
+              <SelectItem key={t.label} value={t.label} className="text-slate-300 text-xs focus:bg-slate-800">
+                {t.label}
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
 
-        <textarea
-          value={queryInput}
-          onChange={(e) => setQueryInput(e.target.value)}
-          rows={2}
-          className='flex-1 p-2 bg-gray-700 text-gray-100 border border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono text-sm'
-          placeholder='Enter Cypher query...'
+        <div className="flex-1 relative">
+          <textarea
+            value={queryInput}
+            onChange={e => setQueryInput(e.target.value)}
+            rows={1}
+            onKeyDown={e => e.key === 'Enter' && !e.shiftKey && (e.preventDefault(), handleRunQuery())}
+            className="w-full px-3 py-1.5 bg-slate-800/60 border border-slate-700 rounded-md text-slate-200 text-xs
+              font-mono resize-none focus:outline-none focus:ring-1 focus:ring-blue-500/60 placeholder-slate-600
+              leading-5"
+            placeholder="Enter Cypher query… (Enter to run)"
+            style={{ minHeight: 32, maxHeight: 64 }}
           />
+        </div>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleCopyQuery}
+          className="h-8 w-8 p-0 text-slate-500 hover:text-slate-300"
+          title="Copy query"
+        >
+          {copiedQuery ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
+        </Button>
+
         <Button
           onClick={handleRunQuery}
           disabled={isLoading}
-          className='px-3 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 flex items-center justify-center'
-          >
-          {isLoading ? (
-            <div className='h-4 w-4 border-2 border-white border-t-transparent rounded-full animate-spin'></div>
-          ) : (
-            <Play className='h-4 w-4' />
-          )}
+          size="sm"
+          className="h-8 px-3 bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium flex-shrink-0 gap-1.5"
+        >
+          {isLoading
+            ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            : <Play className="w-3.5 h-3.5 fill-current" />}
+          {isLoading ? 'Running…' : 'Run'}
         </Button>
       </div>
+
+      {/* ── Error banner ─────────────────────────────────────────────────────── */}
       {error && (
-        <div
-        className='bg-red-900/50 border border-red-700 text-red-100 px-4 py-3 m-4 rounded-md'
-        role='alert'
-        >
-          <span className='block'>{error}</span>
+        <div className="flex items-center gap-2 px-4 py-2 bg-red-950/60 border-b border-red-800/50 text-red-300 text-xs flex-shrink-0">
+          <span className="flex-1 font-mono">{error}</span>
+          <button onClick={() => setError(null)}><X className="w-3.5 h-3.5" /></button>
         </div>
       )}
-      <div className='flex flex-1 overflow-hidden'>
-        <div
-          id='graph-container'
-          className='flex-1 overflow-auto'
-          style={{ height: 'calc(100vh - 200px)' }}
-          >
-          {nodes.length === 0 ? (
-            <p className='text-gray-500 italic text-center p-4'>
-              Run a query to visualize the graph
-            </p>
+
+      {/* ── Main area ────────────────────────────────────────────────────────── */}
+      <div className="flex flex-1 overflow-hidden">
+
+        {/* Canvas area */}
+        <div className="relative flex-1 overflow-hidden"
+          style={{
+            background: '#0a0f1e',
+            backgroundImage: 'radial-gradient(circle, #1e293b 1px, transparent 1px)',
+            backgroundSize: '24px 24px',
+          }}
+        >
+          {/* Graph */}
+          {nodes.length === 0 && !isLoading ? (
+            <EmptyState onRun={handleRunQuery} />
           ) : isMounted ? (
-            <DynamicNVLComponents
-            nodes={nodes}
-            relationships={relationships}
-            onNodeClick={handleNodeClick}
+            <VisGraphCanvas
+              ref={canvasRef}
+              nodes={nodes}
+              relationships={relationships}
+              onNodeClick={node => setSelectedNode(node)}
+              onStabilized={() => setIsStabilizing(false)}
+              physicsEnabled={physicsEnabled}
+              layout={graphLayout}
             />
-          ) : (
-            <p className='text-gray-500 italic text-center p-4'>
-              Loading visualization...
-            </p>
+          ) : null}
+
+          {/* Stabilizing badge */}
+          {isStabilizing && nodes.length > 0 && (
+            <div className="absolute top-3 left-1/2 -translate-x-1/2 bg-slate-900/90 text-slate-300
+              text-xs px-3 py-1.5 rounded-full flex items-center gap-2 border border-slate-700 shadow-lg">
+              <Loader2 className="w-3 h-3 animate-spin text-blue-400" />
+              Arranging {nodes.length} nodes…
+            </div>
+          )}
+
+          {/* Floating graph controls */}
+          <div className="absolute bottom-4 left-4 flex flex-col gap-1">
+            <ControlBtn onClick={() => canvasRef.current?.zoomIn()}    title="Zoom in"         Icon={ZoomIn} />
+            <ControlBtn onClick={() => canvasRef.current?.zoomOut()}   title="Zoom out"        Icon={ZoomOut} />
+            <ControlBtn onClick={() => canvasRef.current?.fitToScreen()} title="Fit to screen" Icon={Maximize2} />
+            <div className="w-full h-px bg-slate-700 my-0.5" />
+            <ControlBtn
+              onClick={handlePhysicsToggle}
+              title={physicsEnabled ? 'Disable physics' : 'Enable physics'}
+              Icon={physicsEnabled ? Zap : ZapOff}
+              active={physicsEnabled}
+              activeColor="text-yellow-400"
+            />
+            <ControlBtn
+              onClick={handleLayoutToggle}
+              title={graphLayout === 'forceDirected' ? 'Switch to hierarchical' : 'Switch to force-directed'}
+              Icon={graphLayout === 'forceDirected' ? GitBranch : Layers}
+              active={graphLayout === 'hierarchical'}
+              activeColor="text-purple-400"
+            />
+          </div>
+
+          {/* Stats pill (bottom-right) */}
+          {nodes.length > 0 && (
+            <div className="absolute bottom-4 right-4 flex items-center gap-3 bg-slate-900/90 border
+              border-slate-700 rounded-full px-4 py-1.5 text-xs text-slate-400 shadow-lg">
+              <span className="flex items-center gap-1.5">
+                <span className="w-2 h-2 rounded-full bg-blue-400 inline-block" />
+                {nodes.length} nodes
+              </span>
+              <span className="text-slate-700">·</span>
+              <span className="flex items-center gap-1.5">
+                <Share2 className="w-3 h-3" />
+                {relationships.length} edges
+              </span>
+            </div>
           )}
         </div>
 
-        <div className='w-72 bg-gray-800 border-l border-gray-700 p-4 overflow-y-auto'>
-          <Collapsible
-            open={isNodesOpen}
-            onOpenChange={setIsNodesOpen}
-            className='mb-4'
-          >
-            <CollapsibleTrigger asChild>
-              <Button variant='ghost' className='w-full justify-between'>
-                <span>Node Types ({nodeTypes.length})</span>
-                {isNodesOpen ? (
-                  <ChevronUp className='h-4 w-4' />
-                ) : (
-                  <ChevronDown className='h-4 w-4' />
-                )}
-              </Button>
-            </CollapsibleTrigger>
-            <CollapsibleContent>
-              <div className='bg-gray-700 rounded-md p-3 border border-gray-600'>
-                {nodeTypes.length > 0 ? (
-                  <div className='grid grid-cols-1 gap-2'>
-                    {nodeTypes.map((type, index) => (
-                      <div key={index} className='flex items-center'>
-                        <div
-                          className='w-3 h-3 mr-2 rounded-full'
-                          style={{
-                            backgroundColor: getColorForLabel(type) as string,
-                          }}
-                        />
-                        <span className='text-gray-200 text-sm'>{type}</span>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <p className='text-gray-400 text-sm italic'>
-                    No nodes to display
-                  </p>
-                )}
-              </div>
-            </CollapsibleContent>
-          </Collapsible>
+        {/* ── Sidebar ──────────────────────────────────────────────────────── */}
+        <aside className="w-72 flex-shrink-0 flex flex-col bg-[#0d1424] border-l border-slate-800 overflow-hidden">
 
-          <Collapsible
-            open={isRelationshipsOpen}
-            onOpenChange={setIsRelationshipsOpen}
-            className='mb-4'
-          >
-            <CollapsibleTrigger asChild>
-              <Button variant='ghost' className='w-full justify-between'>
-                <span>Relationship Types ({relationshipTypes.length})</span>
-                {isRelationshipsOpen ? (
-                  <ChevronUp className='h-4 w-4' />
-                ) : (
-                  <ChevronDown className='h-4 w-4' />
-                )}
-              </Button>
-            </CollapsibleTrigger>
-            <CollapsibleContent>
-              <div className='bg-gray-700 rounded-md p-3 border border-gray-600'>
-                {relationshipTypes.length > 0 ? (
-                  <div className='grid grid-cols-1 gap-2'>
-                    {relationshipTypes.map((type, index) => (
-                      <div key={index} className='flex items-center'>
-                        <div className='w-8 h-[2px] mr-2 bg-blue-400'></div>
-                        <span className='text-gray-200 text-sm'>{type}</span>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <p className='text-gray-400 text-sm italic'>
-                    No relationships to display
-                  </p>
-                )}
-              </div>
-            </CollapsibleContent>
-          </Collapsible>
+          {/* Search */}
+          <div className="px-3 pt-3 pb-2 border-b border-slate-800">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-slate-500" />
+              <input
+                value={searchTerm}
+                onChange={e => setSearchTerm(e.target.value)}
+                placeholder="Filter node types…"
+                className="w-full pl-8 pr-8 py-1.5 bg-slate-800/60 border border-slate-700 rounded-md
+                  text-xs text-slate-300 placeholder-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500/60"
+              />
+              {searchTerm && (
+                <button onClick={() => setSearchTerm('')}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300">
+                  <X className="w-3.5 h-3.5" />
+                </button>
+              )}
+            </div>
+          </div>
 
-          <Collapsible
-            open={isPropertiesOpen}
-            onOpenChange={setIsPropertiesOpen}
-            className='mb-4'
-          >
-            <CollapsibleTrigger asChild>
-              <Button variant='ghost' className='w-full justify-between'>
-                <span className='flex items-center'>
-                  <Info className='h-4 w-4 mr-2' />
-                  Node Properties
-                </span>
-                {isPropertiesOpen ? (
-                  <ChevronUp className='h-4 w-4' />
-                ) : (
-                  <ChevronDown className='h-4 w-4' />
-                )}
-              </Button>
-            </CollapsibleTrigger>
-            <CollapsibleContent className='overflow-x-auto'>
-              <div className='bg-gray-700 rounded-md p-3 border border-gray-600 w-screen'>
-                {selectedNode ? (
-                  <div>
-                    <div className='flex items-center mb-2'>
-                      <div
-                        className='w-3 h-3 mr-2 rounded-full'
-                        style={{
-                          backgroundColor: selectedNode.color || '#CCCCCC',
-                        }}
-                        />
-                      <span className='text-gray-200 font-medium'>
-                        {selectedNode.displayName || selectedNode.caption}
-                      </span>
-                    </div>
-                    <div className='mt-2 text-sm text-gray-400'>
-                      Type: {selectedNode.caption}
-                    </div>
-                    <div className='mt-2'>
-                      {selectedNode.properties &&
-                      Object.keys(selectedNode.properties).length > 0 ? (
-                        <div className='grid grid-cols-1 gap-2'>
-                          {Object.entries(selectedNode.properties).map(
-                            ([key, value]) => (
-                              <div key={key} className='text-sm'>
-                                <span className='text-gray-400'>{key}:</span>{' '}
-                                <span className='text-gray-200'>
-                                  {typeof value === 'object'
-                                    ? JSON.stringify(value)
-                                    : String(value)}
-                                </span>
-                              </div>
-                            )
-                          )}
+          <div className="flex-1 overflow-y-auto scrollbar-thin scrollbar-thumb-slate-700 scrollbar-track-transparent">
+
+            {/* Node type legend */}
+            {filteredNodeTypes.length > 0 && (
+              <SidebarSection title="Node Types" count={Object.keys(nodeTypeCounts).length} icon={<NetworkIcon className="w-3.5 h-3.5" />}>
+                <div className="space-y-1">
+                  {filteredNodeTypes.map(([type, count]) => {
+                    const cfg = NODE_CONFIG[type]
+                    const Icon = cfg?.Icon || HelpCircle
+                    const color = cfg?.color || DEFAULT_COLOR
+                    return (
+                      <div key={type} className="flex items-center gap-2.5 px-1 py-1.5 rounded-md
+                        hover:bg-slate-800/60 cursor-default group transition-colors">
+                        <div className="w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0"
+                          style={{ backgroundColor: color + '22', border: `1.5px solid ${color}` }}>
+                          <Icon className="w-3 h-3" style={{ color }} />
                         </div>
-                      ) : (
-                        <p className='text-gray-400 text-sm italic'>
-                          No properties found
-                        </p>
-                      )}
+                        <div className="flex-1 min-w-0">
+                          <div className="text-xs text-slate-300 truncate">{cfg?.label || type}</div>
+                          <div className="text-[10px] text-slate-600 truncate font-mono">{type}</div>
+                        </div>
+                        <Badge variant="outline"
+                          className="text-[10px] h-4 px-1.5 border-slate-700 text-slate-500 tabular-nums">
+                          {count}
+                        </Badge>
+                      </div>
+                    )
+                  })}
+                </div>
+              </SidebarSection>
+            )}
+
+            {/* Relationship types */}
+            {Object.keys(relTypeCounts).length > 0 && (
+              <SidebarSection title="Relationships" count={relationships.length} icon={<Share2 className="w-3.5 h-3.5" />}>
+                <div className="space-y-1">
+                  {Object.entries(relTypeCounts).map(([type, count]) => {
+                    const color = REL_COLORS[type] || '#94A3B8'
+                    return (
+                      <div key={type} className="flex items-center gap-2.5 px-1 py-1 rounded-md hover:bg-slate-800/60 transition-colors">
+                        <div className="flex items-center gap-1 flex-shrink-0">
+                          <div className="w-4 h-[1.5px]" style={{ backgroundColor: color }} />
+                          <div className="w-0 h-0 border-l-[5px] border-y-[3px] border-y-transparent"
+                            style={{ borderLeftColor: color }} />
+                        </div>
+                        <span className="flex-1 text-xs text-slate-400 font-mono truncate">{type}</span>
+                        <Badge variant="outline"
+                          className="text-[10px] h-4 px-1.5 border-slate-700 text-slate-500 tabular-nums">
+                          {count}
+                        </Badge>
+                      </div>
+                    )
+                  })}
+                </div>
+              </SidebarSection>
+            )}
+
+            {/* Selected node */}
+            <SidebarSection
+              title={selectedNode ? (selectedNode.displayName || selectedNode.caption) : 'Node Inspector'}
+              icon={selectedNode
+                ? <div className="w-3.5 h-3.5 rounded-full flex-shrink-0"
+                    style={{ backgroundColor: NODE_CONFIG[selectedNode.caption]?.color || DEFAULT_COLOR }} />
+                : <HelpCircle className="w-3.5 h-3.5" />}
+              defaultOpen
+            >
+              {selectedNode ? (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    {(() => {
+                      const cfg = NODE_CONFIG[selectedNode.caption]
+                      const Icon = cfg?.Icon || HelpCircle
+                      const color = cfg?.color || DEFAULT_COLOR
+                      return (
+                        <div className="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0"
+                          style={{ backgroundColor: color + '22', border: `2px solid ${color}` }}>
+                          <Icon className="w-4 h-4" style={{ color }} />
+                        </div>
+                      )
+                    })()}
+                    <div>
+                      <div className="text-xs font-semibold text-slate-200 break-all leading-tight">
+                        {selectedNode.displayName || selectedNode.caption}
+                      </div>
+                      <div className="text-[10px] text-slate-500 font-mono mt-0.5">{selectedNode.caption}</div>
                     </div>
                   </div>
-                ) : (
-                  <p className='text-gray-400 text-sm italic'>
-                    Click on a node to view its properties
-                  </p>
-                )}
-              </div>
-            </CollapsibleContent>
-          </Collapsible>
+
+                  {selectedNode.properties && Object.keys(selectedNode.properties).length > 0 && (
+                    <div className="bg-slate-900/60 rounded-md border border-slate-800 overflow-hidden">
+                      {Object.entries(selectedNode.properties).map(([k, v], i) => (
+                        <div key={k}
+                          className={`flex gap-2 px-2.5 py-1.5 text-xs ${i > 0 ? 'border-t border-slate-800/60' : ''}`}>
+                          <span className="text-slate-500 font-mono flex-shrink-0 w-24 truncate">{k}</span>
+                          <span className="text-slate-300 break-all font-mono text-[10px]">
+                            {typeof v === 'object' ? JSON.stringify(v) : String(v).slice(0, 120)}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <p className="text-xs text-slate-600 italic px-1">Click any node in the graph to inspect its properties.</p>
+              )}
+            </SidebarSection>
+
+          </div>
+        </aside>
+      </div>
+    </div>
+  )
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function ControlBtn({
+  onClick, title, Icon, active = false, activeColor = 'text-blue-400',
+}: {
+  onClick: () => void
+  title: string
+  Icon: React.ComponentType<any>
+  active?: boolean
+  activeColor?: string
+}) {
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      className={`w-8 h-8 rounded-md flex items-center justify-center transition-colors
+        bg-slate-900/90 border border-slate-700 shadow-lg
+        hover:bg-slate-800 hover:border-slate-600
+        ${active ? activeColor : 'text-slate-400 hover:text-slate-200'}`}
+    >
+      <Icon className="w-3.5 h-3.5" />
+    </button>
+  )
+}
+
+function SidebarSection({
+  title,
+  icon,
+  count,
+  defaultOpen = false,
+  children,
+}: {
+  title: string
+  icon?: React.ReactNode
+  count?: number
+  defaultOpen?: boolean
+  children: React.ReactNode
+}) {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <div className="border-b border-slate-800/60">
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-slate-800/40 transition-colors"
+      >
+        <span className="text-slate-500">{icon}</span>
+        <span className="flex-1 text-xs font-semibold text-slate-400 uppercase tracking-wider truncate">{title}</span>
+        {count !== undefined && (
+          <span className="text-[10px] text-slate-600 tabular-nums mr-1">{count}</span>
+        )}
+        {open
+          ? <ChevronDown className="w-3.5 h-3.5 text-slate-600 flex-shrink-0" />
+          : <ChevronRight className="w-3.5 h-3.5 text-slate-600 flex-shrink-0" />}
+      </button>
+      {open && <div className="px-3 pb-3">{children}</div>}
+    </div>
+  )
+}
+
+function EmptyState({ onRun }: { onRun: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-5 px-8 text-center">
+      <div className="relative">
+        <div className="w-20 h-20 rounded-full bg-slate-800/60 border border-slate-700 flex items-center justify-center">
+          <NetworkIcon className="w-9 h-9 text-slate-600" />
+        </div>
+        <div className="absolute -top-1 -right-1 w-6 h-6 rounded-full bg-blue-600/20 border border-blue-500/40
+          flex items-center justify-center">
+          <Database className="w-3 h-3 text-blue-400" />
         </div>
       </div>
+      <div>
+        <p className="text-slate-300 font-semibold mb-1">No graph data yet</p>
+        <p className="text-slate-600 text-xs leading-relaxed">
+          Select a query template or write a Cypher query,<br />then click <strong className="text-slate-400">Run</strong> to visualize the codebase graph.
+        </p>
+      </div>
+      <button
+        onClick={onRun}
+        className="flex items-center gap-2 px-4 py-2 bg-blue-600/20 hover:bg-blue-600/30 border border-blue-500/40
+          rounded-md text-blue-300 text-xs font-medium transition-colors"
+      >
+        <Play className="w-3.5 h-3.5 fill-current" />
+        Run default query
+      </button>
     </div>
   )
 }

--- a/frontend/components/neo4j-graph-visualizer.tsx
+++ b/frontend/components/neo4j-graph-visualizer.tsx
@@ -45,12 +45,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import React from 'react'
 import type { VisGraphCanvasHandle } from './vis-graph-canvas'
 
-// Dynamically load vis-network canvas (no SSR)
-const VisGraphCanvas = dynamic(() => import('./vis-graph-canvas'), { ssr: false })
-
-// ─── Types ────────────────────────────────────────────────────────────────────
+// ─── Shared types ─────────────────────────────────────────────────────────────
 interface NodeData {
   id: string
   caption: string
@@ -65,6 +63,24 @@ interface EdgeData {
   to: string
   caption: string
 }
+
+interface VisGraphCanvasProps {
+  nodes: NodeData[]
+  relationships: EdgeData[]
+  onNodeClick?: (node: NodeData | null) => void
+  onStabilized?: () => void
+  physicsEnabled?: boolean
+  layout?: 'forceDirected' | 'hierarchical'
+}
+
+// Dynamically load vis-network canvas (no SSR).
+// Cast restores the forwardRef typing that next/dynamic erases.
+const VisGraphCanvas = dynamic(
+  () => import('./vis-graph-canvas'),
+  { ssr: false }
+) as React.ForwardRefExoticComponent<
+  VisGraphCanvasProps & React.RefAttributes<VisGraphCanvasHandle>
+>
 
 interface Neo4jGraphProps {
   uri: string

--- a/frontend/components/vis-graph-canvas.tsx
+++ b/frontend/components/vis-graph-canvas.tsx
@@ -1,0 +1,311 @@
+'use client'
+
+import { useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
+
+interface NodeData {
+  id: string
+  caption: string
+  color?: string
+  properties?: Record<string, any>
+  displayName?: string
+}
+
+interface EdgeData {
+  id: string
+  from: string
+  to: string
+  caption: string
+}
+
+interface VisGraphCanvasProps {
+  nodes: NodeData[]
+  relationships: EdgeData[]
+  onNodeClick?: (node: NodeData | null) => void
+  onStabilized?: () => void
+  physicsEnabled?: boolean
+  layout?: 'forceDirected' | 'hierarchical'
+}
+
+export interface VisGraphCanvasHandle {
+  zoomIn(): void
+  zoomOut(): void
+  fitToScreen(): void
+  togglePhysics(enabled: boolean): void
+}
+
+// ─── Icon factory ─────────────────────────────────────────────────────────────
+// Each icon is a white Lucide-style path drawn inside a colored circle (64×64 SVG).
+function makeSvgIcon(color: string, pathElements: string): string {
+  const svg = [
+    '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">',
+    `<circle cx="32" cy="32" r="30" fill="${color}"/>`,
+    // scale the 24-px Lucide viewBox up to fill the circle
+    '<g transform="translate(8,8) scale(2)" stroke="white" fill="none"',
+    ' stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">',
+    pathElements,
+    '</g>',
+    '</svg>',
+  ].join('')
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+}
+
+const ICONS: Record<string, string> = {
+  DataFile: makeSvgIcon('#FF6B6B', [
+    '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>',
+    '<polyline points="14 2 14 8 20 8"/>',
+    '<polyline points="10 13 8 15 10 17"/>',
+    '<polyline points="14 13 16 15 14 17"/>',
+  ].join('')),
+
+  DocumentationFile: makeSvgIcon('#4D8AF0', [
+    '<path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>',
+    '<path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>',
+  ].join('')),
+
+  Folder: makeSvgIcon('#6BCB77', [
+    '<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>',
+  ].join('')),
+
+  Function: makeSvgIcon('#845EC2', [
+    '<path d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5c0 1.1.9 2 2 2h1"/>',
+    '<path d="M16 21h1a2 2 0 0 0 2-2v-5c0-1.1.9-2 2-2a2 2 0 0 1-2-2V5a2 2 0 0 0-2-2h-1"/>',
+  ].join('')),
+
+  ApiEndpoint: makeSvgIcon('#F97316', [
+    '<circle cx="12" cy="12" r="10"/>',
+    '<path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>',
+    '<line x1="2" y1="12" x2="22" y2="12"/>',
+  ].join('')),
+
+  TemplateMarkupFile: makeSvgIcon('#F59E0B', [
+    '<rect x="3" y="3" width="18" height="18" rx="2"/>',
+    '<line x1="3" y1="9" x2="21" y2="9"/>',
+    '<line x1="9" y1="21" x2="9" y2="9"/>',
+  ].join('')),
+
+  TestingFile: makeSvgIcon('#60A5FA', [
+    '<path d="M14 2v6l3 11H7L10 8V2"/>',
+    '<line x1="8" y1="2" x2="16" y2="2"/>',
+    '<path d="M6.4 15.1a9 9 0 0 0 11.2 0"/>',
+  ].join('')),
+}
+
+const COLORS: Record<string, string> = {
+  DataFile: '#FF6B6B',
+  DocumentationFile: '#4D8AF0',
+  Folder: '#6BCB77',
+  Function: '#845EC2',
+  ApiEndpoint: '#F97316',
+  TemplateMarkupFile: '#F59E0B',
+  TestingFile: '#60A5FA',
+}
+
+const DEFAULT_ICON = makeSvgIcon('#94A3B8', [
+  '<circle cx="12" cy="12" r="10"/>',
+  '<line x1="12" y1="8" x2="12" y2="16"/>',
+  '<line x1="8" y1="12" x2="16" y2="12"/>',
+].join(''))
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+function clip(str: string, max = 22): string {
+  return str.length <= max ? str : str.slice(0, max - 1) + '…'
+}
+
+function nodeTooltip(node: NodeData): string {
+  const rows = Object.entries(node.properties || {})
+    .slice(0, 6)
+    .map(([k, v]) => {
+      const val = typeof v === 'object' ? JSON.stringify(v) : String(v)
+      return `<tr>
+        <td style="color:#94a3b8;padding:2px 10px 2px 0;white-space:nowrap">${k}</td>
+        <td style="color:#e2e8f0;word-break:break-all">${val.slice(0, 60)}</td>
+      </tr>`
+    })
+    .join('')
+  return `<div style="background:#1e293b;border:1px solid #334155;border-radius:8px;
+    padding:10px 14px;max-width:320px;font-family:system-ui,sans-serif;font-size:12px;line-height:1.5">
+    <div style="font-weight:700;color:#f1f5f9;margin-bottom:4px;font-size:13px">
+      ${node.displayName || node.caption}
+    </div>
+    <div style="color:#64748b;margin-bottom:6px">${node.caption}</div>
+    ${rows ? `<table style="border-collapse:collapse">${rows}</table>` : ''}
+  </div>`
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+const VisGraphCanvas = forwardRef<VisGraphCanvasHandle, VisGraphCanvasProps>(
+  function VisGraphCanvas(
+    {
+      nodes,
+      relationships,
+      onNodeClick,
+      onStabilized,
+      physicsEnabled = true,
+      layout = 'forceDirected',
+    },
+    ref
+  ) {
+    const containerRef = useRef<HTMLDivElement>(null)
+    const networkRef = useRef<any>(null)
+    const nodeMapRef = useRef<Map<string, NodeData>>(new Map())
+
+    useImperativeHandle(ref, () => ({
+      zoomIn() {
+        if (!networkRef.current) return
+        const s = networkRef.current.getScale()
+        networkRef.current.moveTo({ scale: s * 1.25, animation: { duration: 300, easingFunction: 'easeInOutQuad' } })
+      },
+      zoomOut() {
+        if (!networkRef.current) return
+        const s = networkRef.current.getScale()
+        networkRef.current.moveTo({ scale: s * 0.8, animation: { duration: 300, easingFunction: 'easeInOutQuad' } })
+      },
+      fitToScreen() {
+        networkRef.current?.fit({ animation: { duration: 600, easingFunction: 'easeInOutQuad' } })
+      },
+      togglePhysics(enabled: boolean) {
+        networkRef.current?.setOptions({ physics: { enabled } })
+      },
+    }))
+
+    // Keep a fresh node map for click lookups
+    useEffect(() => {
+      nodeMapRef.current = new Map(nodes.map(n => [n.id, n]))
+    }, [nodes])
+
+    useEffect(() => {
+      if (!containerRef.current) return
+
+      let mounted = true
+
+      const init = async () => {
+        const [{ Network }, { DataSet }] = await Promise.all([
+          import('vis-network'),
+          import('vis-data'),
+        ])
+        if (!mounted || !containerRef.current) return
+
+        // ── Build vis node objects ──────────────────────────────────────────
+        const visNodes = nodes.map(node => {
+          const color = COLORS[node.caption] ?? '#94A3B8'
+          return {
+            id: node.id,
+            label: clip(node.displayName || node.caption),
+            shape: 'circularImage',
+            image: ICONS[node.caption] ?? DEFAULT_ICON,
+            size: 28,
+            borderWidth: 2.5,
+            borderWidthSelected: 5,
+            color: {
+              border: color,
+              background: color + '22',
+              highlight: { border: color, background: color + '44' },
+              hover: { border: color, background: color + '33' },
+            },
+            font: {
+              color: '#f1f5f9',
+              size: 11,
+              face: 'Inter, system-ui, sans-serif',
+              strokeWidth: 3,
+              strokeColor: '#0f172a',
+            },
+            shadow: { enabled: true, color: color + '55', size: 10, x: 0, y: 3 },
+            title: nodeTooltip(node),
+          }
+        })
+
+        // ── Build vis edge objects ──────────────────────────────────────────
+        const visEdges = relationships.map(rel => ({
+          id: rel.id,
+          from: rel.from,
+          to: rel.to,
+          label: rel.caption,
+          arrows: { to: { enabled: true, scaleFactor: 0.65, type: 'arrow' } },
+          color: { color: '#334155', highlight: '#94a3b8', hover: '#475569' },
+          font: {
+            color: '#94a3b8',
+            size: 10,
+            face: 'monospace',
+            strokeWidth: 2,
+            strokeColor: '#0f172a',
+            align: 'middle',
+          },
+          smooth: { enabled: true, type: 'dynamic' },
+          width: 1.5,
+          selectionWidth: 3,
+          hoverWidth: 2.5,
+        }))
+
+        // ── Options ────────────────────────────────────────────────────────
+        const options: any = {
+          physics: {
+            enabled: physicsEnabled,
+            solver: 'forceAtlas2Based',
+            forceAtlas2Based: {
+              gravitationalConstant: -80,
+              centralGravity: 0.01,
+              springLength: 130,
+              springConstant: 0.05,
+              damping: 0.4,
+              avoidOverlap: 0.6,
+            },
+            stabilization: { enabled: true, iterations: 300, updateInterval: 25 },
+          },
+          layout:
+            layout === 'hierarchical'
+              ? {
+                  hierarchical: {
+                    enabled: true,
+                    direction: 'UD',
+                    sortMethod: 'directed',
+                    nodeSpacing: 120,
+                    levelSeparation: 180,
+                  },
+                }
+              : { improvedLayout: true, randomSeed: 42 },
+          interaction: {
+            hover: true,
+            tooltipDelay: 200,
+            zoomView: true,
+            dragView: true,
+            multiselect: false,
+            navigationButtons: false,
+            keyboard: false,
+          },
+        }
+
+        const network = new Network(
+          containerRef.current!,
+          { nodes: new DataSet(visNodes), edges: new DataSet(visEdges) },
+          options
+        )
+        networkRef.current = network
+
+        network.on('click', (params: any) => {
+          if (params.nodes.length > 0) {
+            const data = nodeMapRef.current.get(params.nodes[0] as string)
+            if (data) onNodeClick?.(data)
+          } else {
+            onNodeClick?.(null)
+          }
+        })
+
+        network.on('stabilized', () => onStabilized?.())
+      }
+
+      init()
+
+      return () => {
+        mounted = false
+        if (networkRef.current) {
+          networkRef.current.destroy()
+          networkRef.current = null
+        }
+      }
+    }, [nodes, relationships, physicsEnabled, layout])
+
+    return <div ref={containerRef} className="w-full h-full" />
+  }
+)
+
+export default VisGraphCanvas


### PR DESCRIPTION
…cons

- Replace @neo4j-nvl with vis-network for richer graph rendering
- Add vis-graph-canvas.tsx with per-type SVG circular icons (DataFile, DocumentationFile, Folder, Function, ApiEndpoint, TemplateMarkupFile, TestingFile), physics simulation, hierarchical layout, and zoom controls exposed via forwardRef
- Rewrite neo4j-graph-visualizer.tsx: dot-grid canvas background, floating zoom/fit/physics/layout controls, collapsible sidebar with node-type legend (counts + icons), relationship legend with directional arrows, node inspector panel, and Cypher search bar
- Improve explorer/page.tsx: header bar with repo name/link, icon-labelled tab triggers, auto-switch to Code tab on file select
- Improve file-tree.tsx: 30+ extension-to-icon mappings with colours, indent guide lines, selected-file highlight, test/config file heuristics